### PR TITLE
Fix base64 encoding

### DIFF
--- a/finder/finder.go
+++ b/finder/finder.go
@@ -112,6 +112,7 @@ func (f *Finder) FindFiles(directory string) ([]Resource, error) {
 			return nil, err
 		}
 		gw.Close()
+		b64w.Close()
 
 		//
 		// Add the filename + data, which is now encoded


### PR DESCRIPTION
Base64 buffer was not closed leaving unflushed data in the buffer
leading to unexpected end of file error on decompression.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>